### PR TITLE
Update internal status when Stopped

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -386,6 +386,13 @@ class MediaConnection {
         })
 
         this.media.on('message', (message: any) => this.parseMessage(message))
+
+        this.media.on('close', () => {
+          // Sony cast speakers CLOSE when powered down, and don't send updates
+          // Update internal state
+          this.monitor.setPlayState('IDLE');
+          this.monitor.setMedia({});
+        })
     }
 
     pause() {

--- a/index.ts
+++ b/index.ts
@@ -388,10 +388,9 @@ class MediaConnection {
         this.media.on('message', (message: any) => this.parseMessage(message))
 
         this.media.on('close', () => {
-          // Sony cast speakers CLOSE when powered down, and don't send updates
-          // Update internal state
-          this.monitor.setPlayState('IDLE')
-          this.monitor.setMedia({})
+          // This is needed particularly for Chromecast audio & enabled speakers
+          // Update internal state, but leave the other state variables alone
+          this.monitor.setPowerState('off')
         })
     }
 

--- a/index.ts
+++ b/index.ts
@@ -390,8 +390,8 @@ class MediaConnection {
         this.media.on('close', () => {
           // Sony cast speakers CLOSE when powered down, and don't send updates
           // Update internal state
-          this.monitor.setPlayState('IDLE');
-          this.monitor.setMedia({});
+          this.monitor.setPlayState('IDLE')
+          this.monitor.setMedia({})
         })
     }
 


### PR DESCRIPTION
Sony Chromecast speakers, when "powered off" when casting, only manifest this to castv2-device-monitor by closing the media connection.

This causes the internal state of castv2-device-monitor to be out of sync with reality.

This patch sets `playerState: 'IDLE'` and `media: {}` when this happens.  

I'd set `power: 'off'` as well, but that seems overly brutal, and hardware-specific.